### PR TITLE
You won't believe this one simple trick to make chroot-build work properly!

### DIFF
--- a/scripts/chroot-build
+++ b/scripts/chroot-build
@@ -22,6 +22,7 @@ function umount_system_fs ()
 mount_system_fs &&
 
 mkdir $ISO_TARGET/run/lock &&
+mkdir $ISO_TARGET/run/lock/lunar &&
 
 chroot "$ISO_TARGET" "$@"
 RESULT=$?


### PR DESCRIPTION
`lin` was failing for every installation on account of the
/var/lock/lunar directory not existing, and that being where it expects
to find its lockfiles.

So when building the new /var/lock upon chroot creation, also make a
/var/lock/lunar directory to put the lockfiles into.