### PR TITLE
Add libmnl to modules.iso to fix the rescue shell `ip` command

### DIFF
--- a/conf/modules.iso
+++ b/conf/modules.iso
@@ -41,6 +41,7 @@ ISO_MODULES=acl            \
             libgpg-error   \
             libidn         \
             libmpc         \
+            libmnl         \
             libtool        \
             Linux-PAM      \
             lunar          \


### PR DESCRIPTION
Apparently the rescue shell's `ip` command doesn't work, on account of
libmnl no being present.  It only adds 13kB to the ISO, so it may as
well be there.