### PR TITLE
iso.mk: Ensure that the efitools module is installed

### DIFF
--- a/mkfiles/iso.mk
+++ b/mkfiles/iso.mk
@@ -127,6 +127,9 @@ $(ISO_TARGET)/.iso-efi: iso-target
 	@mkdir -p $(ISO_TARGET)/EFI/boot $(ISO_TARGET)/loader/entries $(ISO_TARGET)/EFI/lunariso
 	@touch $@
 
+/usr/share/efitools/efi/PreLoader.efi:
+	lin efitools
+
 $(ISO_TARGET)/EFI/boot/bootx64.efi: /usr/share/efitools/efi/PreLoader.efi
 	@cp $< $@
 


### PR DESCRIPTION
If a Makefile is going to ask for files, it should probably know how to
ensure that they're there.