### PR TITLE
With libressl in core, it conflicts with openssl.

### DIFF
--- a/conf/modules.exclude
+++ b/conf/modules.exclude
@@ -1,1 +1,1 @@
-EXCLUDE_MODULES=grub theedge udev memtest86+
+EXCLUDE_MODULES=grub theedge udev memtest86+ libressl


### PR DESCRIPTION
So for the moment, avoid compiling libressl to see how badly this breaks
the ISO.