### PR TITLE
stage2 gcc build: Explicitly include gmp, mpfr and libmpc.

### DIFF
--- a/conf/modules.stage2
+++ b/conf/modules.stage2
@@ -1,1 +1,1 @@
-STAGE2_MODULES=fhs kernel-headers glibc gcc binutils Linux-PAM
+STAGE2_MODULES=fhs kernel-headers glibc gmp mpfr libmpc gcc binutils Linux-PAM


### PR DESCRIPTION
`lin gcc` seems to be missing them because the fact that they're
installed seems to be cached.

Don't merge this right away--I'm still waiting to confirm whether it actually fixes the iso build.