### PR TITLE
Temporarily exclude pkgconf from the iso build.

### DIFF
--- a/conf/modules.exclude
+++ b/conf/modules.exclude
@@ -1,1 +1,1 @@
-EXCLUDE_MODULES=grub theedge udev memtest86+ libressl
+EXCLUDE_MODULES=grub theedge udev memtest86+ libressl pkgconf


### PR DESCRIPTION
The presence of pkgconf breaks the build.  It's a proposed
replacement for pkgconfig, but it's not verified yet, so leave it
here, but don't build it until we know it works well.