### PR TITLE
lunar-install: Get rid of jfs.

### DIFF
--- a/lunar-install/sbin/lunar-install
+++ b/lunar-install/sbin/lunar-install
@@ -398,7 +398,6 @@ menu_get_filesystem()
     "ext3"      "$EXT3"    \
     "ext2"      "$EXT2"    \
     "xfs"       "$XFS"     \
-    "jfs"       "$JFS"     \
     "vfat"      "$VFAT"    \
     "swap"      "$SWAP"
 }
@@ -527,7 +526,7 @@ determine_mount_opts()
     if [ "$2" == "swap" ]; then
       echo "defaults,discard"
     else
-      if [[ "$2" =~ (ext4|btrfs|xfs|jfs) ]]; then
+      if [[ "$2" =~ (ext4|btrfs|xfs) ]]; then
         echo "defaults,noatime,discard"
       else
         echo "defaults,noatime"
@@ -759,9 +758,6 @@ menu_select_partitions()
     fi &&
 
     case "$FSYS" in
-    #xfs|jfs)
-    # msgbox "Selecting XFS or JFS for your root and/or boot filesystem *requires* you to compile a kernel later on with XFS or JFS built in to the kernel. The default pre-compiled lunar-linux kernel will NOT work in your case!"
-    # ;;
       btrfs)
         msgbox "Selecting btrfs as /boot is only supported with grub2, you will need to create a /boot partition and format it as ext2, ext3 or ext4 in order to use different bootloaders."
         ;;
@@ -786,8 +782,6 @@ menu_select_partitions()
     FSCK_PASS=$(determine_fsck_pass $FSYS $MNTPNT) &&
     if [ "$FSYS" == "xfs" ]; then
       FORCE="-f"
-    elif [ "$FSYS" == "jfs" ]; then
-      FORCE="-q"
     elif [[ "$FSYS" =~ ext[234] ]]; then
       FORCE="-F"
     elif [[ "$FSYS" == "btrfs" ]]; then
@@ -1383,8 +1377,6 @@ set_fs_label() {
     xfs)
       xfs_admin -L $LABEL $PART &> /dev/null
       ;;
-    jfs)
-      jfs_tune -L $LABEL $PART &> /dev/null
       ;;
     swap)
       mkswap -L swap${PART##*/} $PART &> /dev/null


### PR DESCRIPTION
jfsutils doesn't compile with glibc 2.28, and nobody seems to care about
it anyway.