### PR TITLE
modules.iso: Add Perl to the iso.

### DIFF
--- a/conf/modules.iso
+++ b/conf/modules.iso
@@ -62,6 +62,7 @@ ISO_MODULES=acl            \
             openssh        \
             openssl        \
             parted         \
+            perl           \
             pcre           \
             procps         \
             popt           \


### PR DESCRIPTION
This isn't because I want Perl to work when you're installing, but
because vim installs after Perl, picks up the fact that Perl is
installed, and compiles with Perl support, which goes on to make vim
unusable from the iso.