### PR TITLE
lunar-install: Merge /bin with /usr/bin, etc

### DIFF
--- a/lunar-install/sbin/lunar-install
+++ b/lunar-install/sbin/lunar-install
@@ -1102,14 +1102,17 @@ transfer()
 
     (
       percent_msg "Creating base LSB directories"
-      mkdir -p bin boot dev etc home lib mnt media
-      mkdir -p proc root sbin srv tmp usr var opt
+      mkdir -p boot dev etc home mnt media
+      mkdir -p proc root srv tmp usr var opt
       mkdir -p sys
       if [ `arch` == "x86_64" ]; then
         ln -sf /lib lib64
         ln -sf /usr/lib usr/lib64
       fi
       mkdir -p usr/{bin,games,include,lib,libexec,local,sbin,share,src}
+      ln -sf /usr/bin bin
+      ln -sf /usr/lib lib
+      ln -sf /usr/sbin sbin
       mkdir -p usr/share/{dict,doc,info,locale,man,misc,terminfo,zoneinfo}
       mkdir -p usr/share/man/man{1,2,3,4,5,6,7,8}
       ln -sf share/doc usr/doc


### PR DESCRIPTION
It's not 1972 any more, and we don't have /usr mounted on a second RK05
disk which we have to put binaries into because our original RK05 got
full.  Let's merge the contents of /bin and /usr/bin; /lib and /usr/lib;
and /sbin and /usr/sbin.