### PR TITLE
iso.mk: Clean up Python cache files.

### DIFF
--- a/mkfiles/iso.mk
+++ b/mkfiles/iso.mk
@@ -31,6 +31,7 @@ SYSLINUX_FILES=isolinux.bin isohdpfx.bin ldlinux.c32 libcom32.c32 libutil.c32
 $(ISO_TARGET)/.iso-modules: iso-target $(addprefix $(ISO_TARGET)/isolinux/, $(SYSLINUX_FILES))
 	@echo iso-modules
 	@yes n | tr -d '\n' | $(ISO_SOURCE)/scripts/chroot-build lrm -n $(filter-out $(ISO_MODULES), $(ALL_MODULES))
+	@rm -rf $(ISO_TARGET)/usr/lib/python*
 	@touch $@
 
 iso-modules: $(ISO_TARGET)/.iso-modules


### PR DESCRIPTION
Meson leaves files all over /usr/lib/python${VERSION} presumably as a
way to cache things to speed up later operations.  Since they aren't
actually written as part of a package install, they're never tracked, so
lrm'ing everything misses them.

Suggestions for improvement welcome!