### PR TITLE
stage 2 hack: Avoid accidentally wiping out systemd's defaults.

### DIFF
--- a/mkfiles/stage2.mk
+++ b/mkfiles/stage2.mk
@@ -106,7 +106,7 @@ $(ISO_TARGET)/.stage2: stage2-toolchain
 	@cp /etc/resolv.conf $(ISO_TARGET)/etc/resolv.conf
 	@ASK_FOR_REBUILDS=n PROMPT_DELAY=0 $(ISO_SOURCE)/scripts/chroot-build bash -c 'for mod in `lsh sort_by_dependency $(filter-out $(KERNEL_MODULES) $(STAGE2_MODULES) $(EXCLUDE_MODULES),$(ALL_MODULES))`; do lin -c $$mod || exit 1; done'
 	# Rebuild systemd again to enable cryptsetup (cyclic dependency)
-	echo 'systemd:cryptsetup:on:optional:-Dlibcryptsetup=true:-Dlibcryptsetup=false' >> $(ISO_TARGET)/var/state/lunar/depends
+	@perl -pe -i 'if(/^systemd:cryptsetup/) { s/:off:/:on:/; }' $(ISO_TARGET)/var/state/lunar/depends
 	@ASK_FOR_REBUILDS=n PROMPT_DELAY=0 $(ISO_SOURCE)/scripts/chroot-build bash -c 'lin -c systemd'
 	@rm -f $(ISO_TARGET)/etc/resolv.conf
 	@touch $@

--- a/mkfiles/stage2.mk
+++ b/mkfiles/stage2.mk
@@ -106,7 +106,7 @@ $(ISO_TARGET)/.stage2: stage2-toolchain
 	@cp /etc/resolv.conf $(ISO_TARGET)/etc/resolv.conf
 	@ASK_FOR_REBUILDS=n PROMPT_DELAY=0 $(ISO_SOURCE)/scripts/chroot-build bash -c 'for mod in `lsh sort_by_dependency $(filter-out $(KERNEL_MODULES) $(STAGE2_MODULES) $(EXCLUDE_MODULES),$(ALL_MODULES))`; do lin -c $$mod || exit 1; done'
 	# Rebuild systemd again to enable cryptsetup (cyclic dependency)
-	@perl -pi -e 'if(/cryptsetup/) { s/$$/ y/; }' $(ISO_TARGET)/var/lib/lunar/moonbase/core/system/systemd/DEPENDS
+	echo 'systemd:cryptsetup:on:optional:-Dlibcryptsetup=true:-Dlibcryptsetup=false' >> $(ISO_TARGET)/var/state/lunar/depends
 	@ASK_FOR_REBUILDS=n PROMPT_DELAY=0 $(ISO_SOURCE)/scripts/chroot-build bash -c 'lin -c systemd'
 	@rm -f $(ISO_TARGET)/etc/resolv.conf
 	@touch $@

--- a/mkfiles/stage2.mk
+++ b/mkfiles/stage2.mk
@@ -105,8 +105,9 @@ $(ISO_TARGET)/.stage2: stage2-toolchain
 	@echo stage2-build
 	@cp /etc/resolv.conf $(ISO_TARGET)/etc/resolv.conf
 	@ASK_FOR_REBUILDS=n PROMPT_DELAY=0 $(ISO_SOURCE)/scripts/chroot-build bash -c 'for mod in `lsh sort_by_dependency $(filter-out $(KERNEL_MODULES) $(STAGE2_MODULES) $(EXCLUDE_MODULES),$(ALL_MODULES))`; do lin -c $$mod || exit 1; done'
-# Rebuild systemd again to enable cryptsetup (cyclic dependency)
-	@ASK_FOR_REBUILDS=n PROMPT_DELAY=0 $(ISO_SOURCE)/scripts/chroot-build bash -c 'lin -cr systemd'
+	# Rebuild systemd again to enable cryptsetup (cyclic dependency)
+	@perl -pi -e 'if(/cryptsetup/) { s/$$/ y/; }' $(ISO_TARGET)/var/lib/lunar/moonbase/core/system/systemd/DEPENDS
+	@ASK_FOR_REBUILDS=n PROMPT_DELAY=0 $(ISO_SOURCE)/scripts/chroot-build bash -c 'lin -c systemd'
 	@rm -f $(ISO_TARGET)/etc/resolv.conf
 	@touch $@
 


### PR DESCRIPTION
This just meddles inside systemd's DEPENDS file and makes cryptsetup
default to on instead of off so we don't have to use lin -r and
blow away the defaults we prepared earlier.