### PR TITLE
installer: THe `loadkeys` command wants a bare keymap.

### DIFF
--- a/lunar-install/sbin/lunar-install
+++ b/lunar-install/sbin/lunar-install
@@ -419,7 +419,7 @@ show_keymaps()
   MAP_FILES=$(echo -e "$azerty\n$colemak\n$dvorak\n$fgGIod\n$olpc\n$qwerty\n$qwertz" | sort | sed "s/\.kmap\.gz//")
 
   for MAP in $MAP_FILES; do
-    echo $MAP
+    echo ${MAP%.map.gz}
     echo keymap
   done
 }


### PR DESCRIPTION
If you try to say `loadkeys jp106.map.gz`, it outputs the wonderful
message "syntax error, unexpected ERROR" and doesn't do anything.

This surprisingly-tiny change fixes https://github.com/lunar-linux/lunar-iso/issues/51 (and also makes the keyboard map selection screen slightly prettier).