### PR TITLE
lunar-install: Run `systemd preset-all` at end of installation

### DIFF
--- a/lunar-install/sbin/lunar-install
+++ b/lunar-install/sbin/lunar-install
@@ -1232,6 +1232,7 @@ transfer()
       # pass through some of the configuration at this point:
       percent_msg "Finishing up installation"
       chroot_run systemd-machine-id-setup 2> /dev/null
+      chroot_run systemctl preset-all 2>/dev/null
       echo -e "KEYMAP=$KEYMAP\nFONT=$CONSOLEFONT" > $TARGET/etc/vconsole.conf
       echo -e "LANG=${LANG:-en_US.utf8}\nLC_ALL=${LANG:-en_US.utf8}" > $TARGET/etc/locale.conf
       [ -z "$EDITOR" ] || echo "export EDITOR=\"$EDITOR\"" > $TARGET/etc/profile.d/editor.rc


### PR DESCRIPTION
This should, among other things, set it up so that tty1 gets a login
prompt after the system reboots.