### PR TITLE
modules.bootstrap: Add openssl to bootstrap modules

### DIFF
--- a/conf/modules.bootstrap
+++ b/conf/modules.bootstrap
@@ -1,1 +1,1 @@
-BOOTSTRAP_MODULES="bash binutils bzip2 coreutils dialog diffutils file findutils flex gawk gcc glib-2 glibc grep gzip installwatch less libcap lunar m4 make net-tools patch pbzip2 perl pkgconf procps readline sed tar texinfo util-linux xz zlib"
+BOOTSTRAP_MODULES="bash binutils bzip2 coreutils dialog diffutils file findutils flex gawk gcc glib-2 glibc grep gzip installwatch less libcap lunar m4 make net-tools openssl patch pbzip2 perl pkgconf procps readline sed tar texinfo util-linux xz zlib"


### PR DESCRIPTION
It seems that nowadays various coreutils commands like sort are using libcrypto, so openssl needs to be part of the bootstrap.