### PR TITLE
conf/modules.bootstrap: add zstd to the bootstrap

### DIFF
--- a/conf/modules.bootstrap
+++ b/conf/modules.bootstrap
@@ -1,1 +1,1 @@
-BOOTSTRAP_MODULES="bash binutils bzip2 coreutils dialog diffutils file findutils flex gawk gcc glib-2 glibc grep gzip installwatch less libcap lunar m4 make net-tools openssl patch pbzip2 perl pkgconf procps readline sed tar texinfo util-linux xz zlib"
+BOOTSTRAP_MODULES="bash binutils bzip2 coreutils dialog diffutils file findutils flex gawk gcc glib-2 glibc grep gzip installwatch less libcap lunar m4 make net-tools openssl patch pbzip2 perl pkgconf procps readline sed tar texinfo util-linux xz zlib zstd"


### PR DESCRIPTION
zstd now gets linked into gcc so it needs to be included in the stage0 bootstrap.