### PR TITLE
Serial installer: no, really!

### DIFF
--- a/efiboot/loader/entries/lunariso-x86_64-cd.conf
+++ b/efiboot/loader/entries/lunariso-x86_64-cd.conf
@@ -1,4 +1,4 @@
 title Lunar-%VERSION%, %CODENAME% (%DATE%), UEFI CD
 linux /isolinux/linux
 initrd /isolinux/initrd
-options root=live:CDLABEL=%LABEL% rd.live.image rd.live.overlay.overlayfs=1 loglevel=3
+options root=live:CDLABEL=%LABEL% rd.live.image rd.live.overlay.overlayfs=1 loglevel=3 console=tty0 console=ttyS0,38400n8

--- a/efiboot/loader/entries/lunariso-x86_64-usb.conf
+++ b/efiboot/loader/entries/lunariso-x86_64-usb.conf
@@ -1,4 +1,4 @@
 title Lunar-%VERSION%, %CODENAME% (%DATE%), UEFI USB
 linux /EFI/lunariso/linux
 initrd /EFI/lunariso/initrd
-options root=live:CDLABEL=%LABEL% rd.live.image rd.live.overlay.overlayfs=1 loglevel=3
+options root=live:CDLABEL=%LABEL% rd.live.image rd.live.overlay.overlayfs=1 loglevel=3 console=tty0 console=ttyS0,38400n8

--- a/isolinux/isolinux.cfg.i686
+++ b/isolinux/isolinux.cfg.i686
@@ -1,5 +1,5 @@
 DEFAULT install
-APPEND initrd=initrd root=live:CDLABEL=%LABEL% rd.live.image rd.live.overlay.overlayfs=1 loglevel=3
+APPEND initrd=initrd root=live:CDLABEL=%LABEL% rd.live.image rd.live.overlay.overlayfs=1 loglevel=3 console=tty0 console=ttyS0,38400n8
 DISPLAY f1.txt
 TIMEOUT 600
 PROMPT 1
@@ -14,9 +14,9 @@ F8 f1.txt
 F9 f1.txt
 LABEL install
 	KERNEL linux
-	APPEND initrd=initrd root=live:CDLABEL=%LABEL% rd.live.image rd.live.overlay.overlayfs=1 loglevel=3 vga=ask
+	APPEND initrd=initrd root=live:CDLABEL=%LABEL% rd.live.image rd.live.overlay.overlayfs=1 loglevel=3 vga=ask console=tty0 console=ttyS0,38400n8
 LABEL novga
 	KERNEL linux
-	APPEND initrd=initrd root=live:CDLABEL=%LABEL% rd.live.image rd.live.overlay.overlayfs=1 loglevel=3 nomodeset
+	APPEND initrd=initrd root=live:CDLABEL=%LABEL% rd.live.image rd.live.overlay.overlayfs=1 loglevel=3 nomodeset console=tty0 console=ttyS0,38400n8
 # uncomment the following line to enable serial console booting
-# SERIAL 0 38400
+SERIAL 0 38400

--- a/isolinux/isolinux.cfg.x86_64
+++ b/isolinux/isolinux.cfg.x86_64
@@ -1,5 +1,5 @@
 DEFAULT install
-APPEND initrd=initrd root=live:CDLABEL=%LABEL% rd.live.image rd.live.overlay.overlayfs=1 loglevel=3
+APPEND initrd=initrd root=live:CDLABEL=%LABEL% rd.live.image rd.live.overlay.overlayfs=1 loglevel=3 console=tty0 console=ttyS0,38400n8
 DISPLAY f1.txt
 TIMEOUT 600
 PROMPT 1
@@ -14,9 +14,9 @@ F8 f1.txt
 F9 f1.txt
 LABEL install
 	KERNEL linux
-	APPEND initrd=initrd root=live:CDLABEL=%LABEL% rd.live.image rd.live.overlay.overlayfs=1 loglevel=3 vga=ask
+	APPEND initrd=initrd root=live:CDLABEL=%LABEL% rd.live.image rd.live.overlay.overlayfs=1 loglevel=3 vga=ask console=tty0 console=ttyS0,38400n8
 LABEL novga
 	KERNEL linux
-	APPEND initrd=initrd root=live:CDLABEL=%LABEL% rd.live.image rd.live.overlay.overlayfs=1 loglevel=3 nomodeset
+	APPEND initrd=initrd root=live:CDLABEL=%LABEL% rd.live.image rd.live.overlay.overlayfs=1 loglevel=3 nomodeset console=tty0 console=ttyS0,38400n8
 # uncomment the following line to enable serial console booting
-# SERIAL 0 38400
+SERIAL 0 38400

--- a/livecd/template/etc/systemd/system/installer.target.wants/installer@ttyS0.service
+++ b/livecd/template/etc/systemd/system/installer.target.wants/installer@ttyS0.service
@@ -1,0 +1,1 @@
+/etc/systemd/system/installer@.service

--- a/livecd/template/etc/systemd/system/installer@.service
+++ b/livecd/template/etc/systemd/system/installer@.service
@@ -15,6 +15,7 @@ Before=getty.target
 ConditionPathExists=/dev/tty0
 
 Conflicts=getty@%i.service
+Conflicts=serial-getty@%i.service
 
 [Service]
 # the VT is cleared by TTYVTDisallocate

--- a/lunar-install/lib/grub.lunar
+++ b/lunar-install/lib/grub.lunar
@@ -26,8 +26,8 @@ make_grub_conf()
   mkdir -p $TARGET/boot/grub
   (
     echo "# uncomment the following 2 lines to enable serial console booting"
-    echo "#serial --unit=0 --speed=38400 --word=8 --parity=no --stop=1"
-    echo "#terminal serial"
+    echo "serial --unit=0 --speed=38400 --word=8 --parity=no --stop=1"
+    echo "terminal serial"
     echo ""
     echo "timeout 30"
     echo "default 0"

--- a/lunar-install/lib/grub2.lunar
+++ b/lunar-install/lib/grub2.lunar
@@ -22,6 +22,17 @@ install_grub2()
     return
   fi
 
+  case `tty` in
+    /dev/ttyS*)
+      mkdir /mnt/etc/default
+      {
+        echo 'GRUB_CMDLINE_LINUX="console=tty1 console=ttyS0,38400n8"'
+        echo 'GRUB_TERMINAL="console serial"'
+        echo 'GRUB_SERIAL_COMMAND="serial --speed=38400 --unit=0 --word=8 --parity=no --stop=1"'
+      } > /mnt/etc/default/grub
+      ;;
+  esac
+
   if [[ ! -v MBR ]]
   then
     DISC=$(echo $ROOT | sed 's/[0-9]*$//')
@@ -46,4 +57,3 @@ install_grub2()
     chroot_run grub-install $MBR
   fi
 }
-


### PR DESCRIPTION
This lets you plug in an old VT100 terminal into your PC's serial port and install Lunar Linux on that. A very useful feature!

But seriously, I looked at what happened when you run "virsh console" and then some virtual machine that you have running. It turns out that "virsh console" attaches to a virtual serial port.

Well, Lunar's installer is entirely textmode anyway--why not use the serial port you get from "virsh console" and allow a completely headless install?

This PR does exactly that. It transparently adds serial-port-install support to a standard Lunar Linux install, so you can install headless on a libvirtd VM (or any other virtual-machine setup that provides a virtual serial connection by way of a VM console), no need to use VNC any more.

Give it a try if you don't feel like building an entire ISO yourself: https://lunar.lart.ca/2023/06/12/development-serial-console-based-installer-iso-for-june-12-2023.html