### PR TITLE
stage2 modules: Add pcre2

### DIFF
--- a/conf/modules.stage2
+++ b/conf/modules.stage2
@@ -1,1 +1,1 @@
-STAGE2_MODULES=fhs kernel-headers glibc gmp mpfr libmpc gcc binutils Linux-PAM
+STAGE2_MODULES=fhs kernel-headers glibc gmp mpfr libmpc gcc binutils Linux-PAM pcre2


### PR DESCRIPTION
It's needed for wget, because pciutils insists on downloading a fresh new pci.ids.bz2 file every single time it builds, defeating the entire point of preloading all the source files before the ISO build starts.