### PR TITLE
Express mkpart

### DIFF
--- a/lunar-install/lib/express_mkpart.lunar
+++ b/lunar-install/lib/express_mkpart.lunar
@@ -73,6 +73,7 @@ express_mkpart() {
 
     PARTITIONS[${#PARTITIONS[@]}]="${DISK}${PARTNUM}:/boot:${BOOT_FS}:$(determine_mount_opts $BOOT_FS):$(determine_fsck_pass /boot)::${FORCE}:yes"
     BOOT=${DISK}${PARTNUM}
+    block_devices add ${DISK}${PARTNUM}
     block_devices use ${DISK}${PARTNUM}
 
     # Root partition
@@ -80,6 +81,7 @@ express_mkpart() {
     parted $DISK --script "mkpart primary ext4 200MB -${SWAPSIZE}M"
     PARTITIONS[${#PARTITIONS[@]}]="${DISK}${PARTNUM}:/:ext4:$(determine_mount_opts ext4):$(determine_fsck_pass /)::-F:yes"
     ROOT=${DISK}${PARTNUM}
+    block_devices add ${DISK}${PARTNUM}
     block_devices use ${DISK}${PARTNUM}
 
     # Swap partition
@@ -87,6 +89,7 @@ express_mkpart() {
     parted $DISK --script "mkpart primary linux-swap -${SWAPSIZE}M 100%"
     PARTITIONS[${#PARTITIONS[@]}]="${DISK}${PARTNUM}:swap:swap:$(determine_mount_opts ext4):$(determine_fsck_pass /)::-f:yes"
     SWAP_ENABLED=1
+    block_devices add ${DISK}${PARTNUM}
     block_devices use ${DISK}${PARTNUM}
 
     # Make sure the rest of the installer sees the new partitions

--- a/lunar-install/lib/express_mkpart.lunar
+++ b/lunar-install/lib/express_mkpart.lunar
@@ -73,7 +73,6 @@ express_mkpart() {
 
     PARTITIONS[${#PARTITIONS[@]}]="${DISK}${PARTNUM}:/boot:${BOOT_FS}:$(determine_mount_opts $BOOT_FS):$(determine_fsck_pass /boot)::${FORCE}:yes"
     BOOT=${DISK}${PARTNUM}
-    block_devices add ${DISK}${PARTNUM}
     block_devices use ${DISK}${PARTNUM}
 
     # Root partition
@@ -81,7 +80,6 @@ express_mkpart() {
     parted $DISK --script "mkpart primary ext4 200MB -${SWAPSIZE}M"
     PARTITIONS[${#PARTITIONS[@]}]="${DISK}${PARTNUM}:/:ext4:$(determine_mount_opts ext4):$(determine_fsck_pass /)::-F:yes"
     ROOT=${DISK}${PARTNUM}
-    block_devices add ${DISK}${PARTNUM}
     block_devices use ${DISK}${PARTNUM}
 
     # Swap partition
@@ -89,12 +87,17 @@ express_mkpart() {
     parted $DISK --script "mkpart primary linux-swap -${SWAPSIZE}M 100%"
     PARTITIONS[${#PARTITIONS[@]}]="${DISK}${PARTNUM}:swap:swap:$(determine_mount_opts ext4):$(determine_fsck_pass /)::-f:yes"
     SWAP_ENABLED=1
-    block_devices add ${DISK}${PARTNUM}
+    S_OK=\\Z2
     block_devices use ${DISK}${PARTNUM}
 
     # Make sure the rest of the installer sees the new partitions
     sync
     partprobe $DISK
 
+    # Now we can skip selecting a swap file (or partition), and we don't
+    # have to select partitions either if we don't want to
     DONE_PARTITIONING=1
+    L_OK=
+    T_OK=
+    STEP=6
 }

--- a/lunar-install/lib/express_mkpart.lunar
+++ b/lunar-install/lib/express_mkpart.lunar
@@ -67,7 +67,7 @@ express_mkpart() {
         ;;
 
         *)
-            FORCE=-f
+            FORCE=-F
         ;;
     esac
 
@@ -78,14 +78,14 @@ express_mkpart() {
     # Root partition
     ((PARTNUM++))
     parted $DISK --script "mkpart primary ext4 200MB -${SWAPSIZE}M"
-    PARTITIONS[${#PARTITIONS[@]}]="${DISK}${PARTNUM}:/:ext4:$(determine_mount_opts ext4):$(determine_fsck_pass /)::${FORCE}:yes"
+    PARTITIONS[${#PARTITIONS[@]}]="${DISK}${PARTNUM}:/:ext4:$(determine_mount_opts ext4):$(determine_fsck_pass /)::-F:yes"
     ROOT=${DISK}${PARTNUM}
     block_devices use ${DISK}${PARTNUM}
 
     # Swap partition
     ((PARTNUM++))
     parted $DISK --script "mkpart primary linux-swap -${SWAPSIZE}M 100%"
-    PARTITIONS[${#PARTITIONS[@]}]="${DISK}${PARTNUM}:swap:swap:$(determine_mount_opts ext4):$(determine_fsck_pass /)::${FORCE}:yes"
+    PARTITIONS[${#PARTITIONS[@]}]="${DISK}${PARTNUM}:swap:swap:$(determine_mount_opts ext4):$(determine_fsck_pass /)::-f:yes"
     SWAP_ENABLED=1
     block_devices use ${DISK}${PARTNUM}
 

--- a/lunar-install/lib/express_mkpart.lunar
+++ b/lunar-install/lib/express_mkpart.lunar
@@ -1,0 +1,84 @@
+#!/bin/bash
+
+#############################################################
+#                                                           #
+# Automatically create a basic partition table on a disk    #
+#                                                           #
+#############################################################
+#                                                           #
+# Copyright 2023 by Dave Brown                              #
+#                                                           #
+#############################################################
+#                                                           #
+# This file is released under the GPLv2                     #
+#                                                           #
+#############################################################
+
+##########################################################################
+# This creates a partition table with the following entries:
+#
+# 1) A boot/EFI partition at the beginning of the disk, arbitrarily
+#    sized at 200M
+# 2) A swap partition at the end of the disk, twice the size of RAM, and
+# 3) A Linux partition between them taking up the remainder of the disk
+#    space.
+##########################################################################
+
+# Partitions format:
+# $PART:$MNTPNT:$FSYS:$MNT_OPTS:$FSCK_PASS:$CHECK:$FORCE:$FORMAT
+
+express_mkpart() {
+    local DISK
+    local BOOT_FS
+    local PART
+    local START
+    local FORCE
+
+    DISK=$1
+    BOOT_FS=ext4
+
+    # Strange calculation (taken from lib/filesystems.lunar) but it ends up 
+    # being 2x[RAM rounded up to 256M blocks]
+    SWAPSIZE=$(awk '/^MemTotal:/ { print (int($2/128000)+1)*256 }' /proc/meminfo)
+
+    parted $DISK --script mklabel gpt
+    PART=0
+    START=0
+
+    if [ ! -d /sys/firmware/efi ]
+    then
+        # BIOS boot partition
+        ((PART++))
+        START=1MB
+        parted $DISK --script "mkpart primary fat32 0 $START"
+        parted $DISK --script "set ${PART} bios_grub on"
+        BOOT_FS=fat32
+    fi
+
+    # boot/EFI partition
+    # Starts at 1MB to give a little room for BIOS boot if this isn't an EFI system
+    ((PART++))
+    parted $DISK --script "mkpart primary $BOOT_FS $START 200MB"
+    parted $DISK --script "set ${PART} boot on"
+    case $BOOT_FS in
+        fat32)
+            FORCE=-F32
+        ;;
+
+        *)
+            FORCE=-f
+        ;;
+    esac
+    PARTITIONS[${#PARTITIONS[@]}]="${DISK}${PART}:/boot:${BOOT_FS}:$(determine_mount_opts $BOOT_FS):$(determine_fsck_pass /boot)::${FORCE}:yes"
+
+    # Root partition
+    ((PART++))
+    parted $DISK --script "mkpart primary ext4 200MB -${SWAPSIZE}M"
+    PARTITIONS[${#PARTITIONS[@]}]="${DISK}${PART}:/:ext4:$(determine_mount_opts ext4):$(determine_fsck_pass /)::${FORCE}:yes"
+
+    # Swap partition
+    ((PART++))
+    parted $DISK --script "mkpart primary linux-swap -${SWAPSIZE}M 100%"
+    PARTITIONS[${#PARTITIONS[@]}]="${DISK}${PART}:swap:swap:$(determine_mount_opts ext4):$(determine_fsck_pass /)::${FORCE}:yes"
+    SWAP_ENABLED=1
+}

--- a/lunar-install/lib/express_mkpart.lunar
+++ b/lunar-install/lib/express_mkpart.lunar
@@ -89,5 +89,9 @@ express_mkpart() {
     SWAP_ENABLED=1
     block_devices use ${DISK}${PARTNUM}
 
+    # Make sure the rest of the installer sees the new partitions
+    sync
+    partprobe $DISK
+
     DONE_PARTITIONING=1
 }

--- a/lunar-install/lib/express_mkpart.lunar
+++ b/lunar-install/lib/express_mkpart.lunar
@@ -34,9 +34,23 @@ express_mkpart() {
     DISK=$1
     BOOT_FS=fat32
 
-    # Strange calculation (taken from lib/filesystems.lunar) but it ends up 
-    # being 2x[RAM rounded up to 256M blocks]
-    SWAPSIZE=$(awk '/^MemTotal:/ { print (int($2/128000)+1)*256 }' /proc/meminfo)
+    SWAPSIZE=$(awk '
+        /^MemTotal:/ {
+            memsize=$2
+
+            # Round swap size up a little bit
+            base_swapsize = (int(memsize/128000)+1)*128
+
+            # If there is more than 8G of RAM, let swap
+            # be memory plus an extra couple of gigabytes
+            #
+            # Otherwise just let it be twice RAM
+            if(memsize > 8388608) {
+                print base_swapsize + 2048
+            } else {
+                print base_swapsize * 2
+            }
+        }' /proc/meminfo)
 
     parted $DISK --script mklabel gpt
 

--- a/lunar-install/lib/express_mkpart.lunar
+++ b/lunar-install/lib/express_mkpart.lunar
@@ -24,44 +24,45 @@
 #    space.
 ##########################################################################
 
-# Partitions format:
-# $PART:$MNTPNT:$FSYS:$MNT_OPTS:$FSCK_PASS:$CHECK:$FORCE:$FORMAT
-
 express_mkpart() {
     local DISK
     local BOOT_FS
-    local PART
+    local PARTNUM
     local START
     local FORCE
 
     DISK=$1
-    BOOT_FS=ext4
+    BOOT_FS=fat32
 
     # Strange calculation (taken from lib/filesystems.lunar) but it ends up 
     # being 2x[RAM rounded up to 256M blocks]
     SWAPSIZE=$(awk '/^MemTotal:/ { print (int($2/128000)+1)*256 }' /proc/meminfo)
 
     parted $DISK --script mklabel gpt
-    PART=0
+
+    PARTNUM=0
     START=0
 
+    # If this isn't an EFI system, make a bit of room at the start of the disk
+    # for grub
     if [ ! -d /sys/firmware/efi ]
     then
         # BIOS boot partition
-        ((PART++))
+        ((PARTNUM++))
         START=1MB
         parted $DISK --script "mkpart primary fat32 0 $START"
-        parted $DISK --script "set ${PART} bios_grub on"
-        BOOT_FS=fat32
+        parted $DISK --script "set ${PARTNUM} bios_grub on"
+        BOOT_FS=ext4
     fi
 
     # boot/EFI partition
-    # Starts at 1MB to give a little room for BIOS boot if this isn't an EFI system
-    ((PART++))
+    ((PARTNUM++))
     parted $DISK --script "mkpart primary $BOOT_FS $START 200MB"
-    parted $DISK --script "set ${PART} boot on"
+    parted $DISK --script "set ${PARTNUM} boot on"
     case $BOOT_FS in
         fat32)
+            # gparted calls it "fat32", but mkfs wants "vfat", so...
+            BOOT_FS=vfat
             FORCE=-F32
         ;;
 
@@ -69,16 +70,24 @@ express_mkpart() {
             FORCE=-f
         ;;
     esac
-    PARTITIONS[${#PARTITIONS[@]}]="${DISK}${PART}:/boot:${BOOT_FS}:$(determine_mount_opts $BOOT_FS):$(determine_fsck_pass /boot)::${FORCE}:yes"
+
+    PARTITIONS[${#PARTITIONS[@]}]="${DISK}${PARTNUM}:/boot:${BOOT_FS}:$(determine_mount_opts $BOOT_FS):$(determine_fsck_pass /boot)::${FORCE}:yes"
+    BOOT=${DISK}${PARTNUM}
+    block_devices use ${DISK}${PARTNUM}
 
     # Root partition
-    ((PART++))
+    ((PARTNUM++))
     parted $DISK --script "mkpart primary ext4 200MB -${SWAPSIZE}M"
-    PARTITIONS[${#PARTITIONS[@]}]="${DISK}${PART}:/:ext4:$(determine_mount_opts ext4):$(determine_fsck_pass /)::${FORCE}:yes"
+    PARTITIONS[${#PARTITIONS[@]}]="${DISK}${PARTNUM}:/:ext4:$(determine_mount_opts ext4):$(determine_fsck_pass /)::${FORCE}:yes"
+    ROOT=${DISK}${PARTNUM}
+    block_devices use ${DISK}${PARTNUM}
 
     # Swap partition
-    ((PART++))
+    ((PARTNUM++))
     parted $DISK --script "mkpart primary linux-swap -${SWAPSIZE}M 100%"
-    PARTITIONS[${#PARTITIONS[@]}]="${DISK}${PART}:swap:swap:$(determine_mount_opts ext4):$(determine_fsck_pass /)::${FORCE}:yes"
+    PARTITIONS[${#PARTITIONS[@]}]="${DISK}${PARTNUM}:swap:swap:$(determine_mount_opts ext4):$(determine_fsck_pass /)::${FORCE}:yes"
     SWAP_ENABLED=1
+    block_devices use ${DISK}${PARTNUM}
+
+    DONE_PARTITIONING=1
 }

--- a/lunar-install/lib/partitions.lunar
+++ b/lunar-install/lib/partitions.lunar
@@ -7,6 +7,7 @@
 # portions Copyright 2003-2004 by tchan, kc8apf             #
 # portions Copyright 2004-2007 by Auke Kok                  #
 # portions Copyright 2008-2017 by Stefan Wold               #
+# portions Copyright 2023 by Dave Brown                     #
 #                                                           #
 #############################################################
 #                                                           #
@@ -41,6 +42,7 @@ menu_get_partition()
 
 partition_discs()
 {
+  EXPRESS="Create basic partition table and select target filesystems automatically"
   CFDISK="Curses based disk partition table manipulator"
   FDISK="Partition table manipulator"
   PARTED="Create, destroy, resize, and copy partitions"
@@ -49,6 +51,7 @@ partition_discs()
 
   DISC=$(menu_get_disc) &&
   PROG=`$DIALOG --title "$TITLE" --menu "$HELP" 0 0 0  \
+          "express_mkpart" "$EXPRESS"                  \
           "cfdisk"  "$CFDISK"                          \
           "fdisk"   "$FDISK"                           \
           "parted"  "$PARTED"` &&


### PR DESCRIPTION
Here is an quick and simple automatic partitioner for people not too concerned about partitioning their disks carefully.

It makes three partitions on a gpt-partitioned disk:
* a /boot, formatted with VFAT for EFI systems or ext4 for BIOS systems
* a swap partition twice the size of RAM (like the swapfile creation code does),
* a root partition, which fills the remainder of the disk

On BIOS systems, it also makes a tiny partition for grub to put its BIOS boot stuff into right at the beginning of the disk.