### PR TITLE
Add hdparm to ISO modules

### DIFF
--- a/conf/modules.iso
+++ b/conf/modules.iso
@@ -28,6 +28,7 @@ ISO_MODULES=acl            \
             gptfdisk       \
             grep           \
             gzip           \
+            hdparm         \
             inih           \
             iproute2       \
             iputils        \


### PR DESCRIPTION
filesystems.lunar uses hdparm to determine whether a disk is an SSD or a spinning disk, and set mount options accordingly.