### PR TITLE
Add hdparm to the ISO

### DIFF
--- a/conf/modules.iso
+++ b/conf/modules.iso
@@ -28,6 +28,7 @@ ISO_MODULES=acl            \
             gptfdisk       \
             grep           \
             gzip           \
+            hdparm         \
             inih           \
             iproute2       \
             iputils        \


### PR DESCRIPTION
Turns out the filesystem creation stuff has been trying to use hdparm for years and years, to figure out whether some disk is a SSD and needs TRIM support, and has just been failing all this time. It's just the screen was clearing before you could see the error message.

So thanks, serial console support I guess. :)