### PR TITLE
VGA mode: Skip asking about video mode on first boot

### DIFF
--- a/isolinux/isolinux.cfg.i686
+++ b/isolinux/isolinux.cfg.i686
@@ -1,4 +1,5 @@
 DEFAULT install
+SERIAL 0 38400
 APPEND initrd=initrd root=live:CDLABEL=%LABEL% rd.live.image rd.live.overlay.overlayfs=1 loglevel=3 console=tty0 console=ttyS0,38400n8
 DISPLAY f1.txt
 TIMEOUT 600
@@ -14,9 +15,7 @@ F8 f1.txt
 F9 f1.txt
 LABEL install
 	KERNEL linux
-	APPEND initrd=initrd root=live:CDLABEL=%LABEL% rd.live.image rd.live.overlay.overlayfs=1 loglevel=3 vga=ask console=tty0 console=ttyS0,38400n8
+	APPEND initrd=initrd root=live:CDLABEL=%LABEL% rd.live.image rd.live.overlay.overlayfs=1 loglevel=3 vga=normal console=tty0 console=ttyS0,38400n8
 LABEL novga
 	KERNEL linux
 	APPEND initrd=initrd root=live:CDLABEL=%LABEL% rd.live.image rd.live.overlay.overlayfs=1 loglevel=3 nomodeset console=tty0 console=ttyS0,38400n8
-# uncomment the following line to enable serial console booting
-SERIAL 0 38400

--- a/isolinux/isolinux.cfg.x86_64
+++ b/isolinux/isolinux.cfg.x86_64
@@ -1,4 +1,5 @@
 DEFAULT install
+SERIAL 0 38400
 APPEND initrd=initrd root=live:CDLABEL=%LABEL% rd.live.image rd.live.overlay.overlayfs=1 loglevel=3 console=tty0 console=ttyS0,38400n8
 DISPLAY f1.txt
 TIMEOUT 600
@@ -14,9 +15,7 @@ F8 f1.txt
 F9 f1.txt
 LABEL install
 	KERNEL linux
-	APPEND initrd=initrd root=live:CDLABEL=%LABEL% rd.live.image rd.live.overlay.overlayfs=1 loglevel=3 vga=ask console=tty0 console=ttyS0,38400n8
+	APPEND initrd=initrd root=live:CDLABEL=%LABEL% rd.live.image rd.live.overlay.overlayfs=1 loglevel=3 vga=normal console=tty0 console=ttyS0,38400n8
 LABEL novga
 	KERNEL linux
 	APPEND initrd=initrd root=live:CDLABEL=%LABEL% rd.live.image rd.live.overlay.overlayfs=1 loglevel=3 nomodeset console=tty0 console=ttyS0,38400n8
-# uncomment the following line to enable serial console booting
-SERIAL 0 38400


### PR DESCRIPTION
It doesn't matter what you choose these days anyway--systemd will just switch the video mode to whatever it likes.

So it's probably safe to let this relic of the past disappear now.