### PR TITLE
Installer: clean up the reboot at the end

### DIFF
--- a/conf/modules.iso
+++ b/conf/modules.iso
@@ -4,6 +4,7 @@ ISO_MODULES=acl            \
             btrfs-progs    \
             bzip2          \
             coreutils      \
+            cpio           \
             cracklib       \
             cryptsetup     \
             dbus           \
@@ -11,6 +12,7 @@ ISO_MODULES=acl            \
             dialog         \
             diffutils      \
             dosfstools     \
+            dracut         \
             e2fsprogs      \
             e3             \
             ed             \

--- a/lunar-install/lib/dialogs.lunar
+++ b/lunar-install/lib/dialogs.lunar
@@ -71,6 +71,10 @@ goodbye()
   PROMPT="Reboot now?"
   if confirm "$PROMPT" "--defaultno"; then
     kill `jobs -p` &> /dev/null
+    touch /run/initramfs/.need_shutdown
+    touch /lib/modules/$(uname -r)/initrd
+    mount --bind /run/initramfs/live/isolinux/initrd /lib/modules/$(uname -r)/initrd
+    /usr/lib/dracut/dracut-initramfs-restore
     shutdown -r now
     exit 0
   else


### PR DESCRIPTION
Annoyed by all those messages at the end of the install saying "could not unmount /dev/loop1: device in use?" I am too!

This takes advantage of dracut's shutdown facility to be able to use the initramfs at shutdown time as well as at startup, to to safely unmount everything at reboot time.