### PR TITLE
express_mkpart: parted's "print devices" prints all devices found

### DIFF
--- a/lunar-install/lib/express_mkpart.lunar
+++ b/lunar-install/lib/express_mkpart.lunar
@@ -53,6 +53,7 @@ express_mkpart() {
         }' /proc/meminfo)
 
     DISKSIZE=$(parted $DISK 'unit mib print devices' |
+               grep $DISK |
                sed 's/.*(\(.*\)mib)/\1/i')
 
     # If swap would be more than 10% disk size, then just use 10% of the


### PR DESCRIPTION
So even though you have to provide the specific device you're interested in on the command line, you still need to go grepping through its output to find the one you want, because it still prints information about everything on your system anyway.