### PR TITLE
password.lunar: fix double password prompt

### DIFF
--- a/lunar-install/lib/password.lunar
+++ b/lunar-install/lib/password.lunar
@@ -19,7 +19,7 @@ set_user_password() {
     PASSWORD2=$($DIALOG --insecure --passwordbox "Set password for user '$USERNAME'\n\nVerify Password:" 0 0) || return 1
 
     if [[ "$PASSWORD" == "$PASSWORD2" ]]; then
-      chroot_run passwd $USERNAME < <(printf "%s\n%s" "$PASSWORD" "$PASSWORD") &> /dev/null
+      chroot_run passwd -s $USERNAME < <(printf "%s\n%s\n" "$PASSWORD" "$PASSWORD") &> /dev/null
     else
       msgbox "Passwords did not match, please enter again."
       unset PASSWORD PASSWORD2


### PR DESCRIPTION
Sometimes it's asking for password twice--once in the dialog, and once again when the password command is actually run.

Turns out there's a flag for the passwd command to tell it to accept input from standard input even if that isn't the current controlling tty.

Also I threw in an extra EOL in the printf to make sure the enter key gets pressed both times.